### PR TITLE
Don't authenticate with AWS if session.handler_id is not "dynamo_session...

### DIFF
--- a/DependencyInjection/Compiler/DynamoDbTablePass.php
+++ b/DependencyInjection/Compiler/DynamoDbTablePass.php
@@ -26,6 +26,10 @@ class DynamoDbTablePass implements CompilerPassInterface
             return;
         }
 
+        if($container->getParameter("session.handler_id") !== "dynamo_session_handler") {
+            return;
+        }
+
         /** @var $client DynamoDbClient */
         $client = $container->get("dynamo_session_client");
 


### PR DESCRIPTION
Don't authenticate with AWS if session.handler_id is not "dynamo_session_handler", issue #1 
