### PR TITLE
Fix alias when using the client service id on configuration

### DIFF
--- a/DependencyInjection/Compiler/DynamoDbTablePass.php
+++ b/DependencyInjection/Compiler/DynamoDbTablePass.php
@@ -22,7 +22,7 @@ class DynamoDbTablePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if(!$container->hasDefinition("dynamo_session_client")) {
+        if(!$container->hasDefinition("dynamo_session_client") && !$container->hasAlias("dynamo_session_client")) {
             return;
         }
 

--- a/DependencyInjection/GWKDynamoSessionExtension.php
+++ b/DependencyInjection/GWKDynamoSessionExtension.php
@@ -54,7 +54,7 @@ class GWKDynamoSessionExtension extends Extension
             $config['dynamo_client_id'] = "dynamo_session_client";
         } else {
             $container->removeDefinition("dynamo_session_client");
-            $container->setAlias("dynamo_session_client", $config['client_id']);
+            $container->setAlias("dynamo_session_client", $config['dynamo_client_id']);
         }
 
         $container->setParameter("dynamo_session_table", $config['table']);


### PR DESCRIPTION
I was having problems configuring the bundle with an existing dynamo db service.

Example configuration array

```php
Array
(
    [table] => staging-session
    [locking_strategy] => pessimistic
    [dynamo_client_id] => infrastructure.dynamodb_client
    [automatic_gc] => 1
    [gc_batch_size] => 25
    [session_lifetime] => 3600
    [read_capacity] => 10
    [write_capacity] => 10
    [aws] => Array
        (
            [region] => eu-west-1
            [key] => somekey
            [secret] => some secret
        )
)
```

Error:

  [Symfony\Component\Debug\Exception\ContextErrorException]
  Notice: Undefined index: client_id in /vagrant/vendor/gwk/dynamo-session-bundle/GWK/DynamoSessionBundle/DependencyInjectio
  n/GWKDynamoSessionExtension.php line 59